### PR TITLE
Update Ruby version in linters workflow

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-ruby@v1
         with:
-          ruby-version: 3.1.x
+          ruby-version: '3.4'
       - name: Setup Rubocop
         run: |
           gem install --no-document rubocop -v '>= 1.0, < 2.0' # https://docs.rubocop.org/en/stable/installation/


### PR DESCRIPTION
Updated Ruby version in the linters workflow to the latest '3.4'